### PR TITLE
Revert "chore(deps): bump watchdog from 1.0.2 to 2.0.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,6 @@ sqlparse==0.4.1
 toml==0.10.2
 typing-extensions==3.7.4.3
 urllib3==1.26.4
-watchdog==2.0.3
+watchdog==1.0.2
 whitenoise==5.2.0
 YubiOTP==1.0.0


### PR DESCRIPTION
Reverts cass-dlcm/splatstats#6